### PR TITLE
fix: `return` is an optional method of iterators

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,7 +51,7 @@ async function* combineAsyncIterators(...iterators) {
     }
     finally {
         // TODO: replace .all with .allSettled
-        await Promise.all(iterators.map((it) => it.return()));
+        await Promise.all(iterators.flatMap((it) => (it.return ? [it.return()] : [])));
     }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -383,7 +383,7 @@
         },
         "@slimio/is": {
             "version": "1.5.1",
-            "resolved": "",
+            "resolved": false,
             "integrity": "sha512-xQ0AgodIE8nHYy508AVmpxqnIr/Ytyz5Xm7I6NQU33+RvDzs94T9c0dTnUWuariByLr1geXXe6kMaTM9TcOIEA==",
             "dev": true
         },

--- a/test/test.js
+++ b/test/test.js
@@ -27,6 +27,23 @@ async function* getThrow(id) {
     throw new Error("oh no!");
 }
 
+function getMinimumAsyncIterable(id) {
+    const max = 3;
+    let i = 0;
+    return {
+        next() {
+            if (i >= max) {
+                return { done: true };
+            } else {
+                return { value: `${id}_${i++}` };
+            }
+        },
+        [Symbol.asyncIterator]() {
+            return this;
+        }
+    };
+};
+
 test("all values must be retrieved (but not in sequence)", async(assert) => {
     const first = getValues("first");
     const second = getValues("second");
@@ -60,6 +77,15 @@ test("combineAsyncIterators must close all iterators when it throw", async(asser
         ]);
 
         assert.isTrue(result.every((row) => row.done === true));
+    }
+});
+
+test("combineAsyncIterators must not throw if iterator lacks optional properties", async(assert) => {
+    const first = getMinimumAsyncIterable("first");
+    const second = getMinimumAsyncIterable("second");
+
+    for await (const value of combineAsyncIterators(first, second)) {
+        // Run iterators until completion. They should not throw.
     }
 });
 


### PR DESCRIPTION
This fixes an issue where iterators that do not provide the optional `return` method cause `combine-async-iterator` to crash.

For example, [Octokit's pagination iterator](https://github.com/octokit/plugin-paginate-rest.js/blob/ce80cc3449418541a388c4d016dd4ebc056c13f3/src/iterator.ts#L25-L57) does not provide this method.

I added tests, checked that `npm test` succeeded with the patch, checked that `npm test` failed without the patch, and ran tests in Node 12.